### PR TITLE
Fixed error cannot access OkHttpClient and Room

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,14 +43,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     //room
-    implementation "androidx.room:room-runtime:$room_version"
+    api "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     androidTestImplementation "androidx.room:room-testing:$room_version"
 
     //retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$logging_interceptor_version"
+    api "com.squareup.okhttp3:logging-interceptor:$logging_interceptor_version"
 
     //coroutine
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"


### PR DESCRIPTION
Fixed errors when modularizing with Dagger Hilt which showed errors such as "cannot access OkHttpClient" and "cannot access Room Database". which is the Dagger Hilt error that appears like "cannot find symbol variable DaggerMyApplication_HiltComponents_ApplicationC"